### PR TITLE
Modification bytes highlight

### DIFF
--- a/src/AppData.hs
+++ b/src/AppData.hs
@@ -54,7 +54,7 @@ data AppState = MkState
     _mmapOffset :: Integer,
     _hexOffset :: Int,
     _fileBuffer :: Vector Word8,
-    _modificationBuffer :: M.Map Int Word8,
+    _modificationBuffer :: M.Map Integer Word8,
     _perfCount :: Int,
     _hexMode :: Bool,
     _enterOffset :: String

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -11,7 +11,7 @@ import Data.Char (chr, isSpace, toUpper)
 import Data.List (dropWhileEnd, foldl1')
 import qualified Data.Map as M
 import Data.Maybe
-import Data.Vector (empty, generateM, (//))
+import Data.Vector (Vector, empty, generateM)
 import Foreign
 import GHC.IO.IOMode
 import Graphics.Vty
@@ -177,45 +177,51 @@ openFile = do
   isFile <- liftIO $ doesFileExist path
   if isFile
     then do
-      perm <- liftIO $ getPermissions path
-      if readable perm
-        then do
-          size <- liftIO $ getFileSize path
-          if size == 0
-            then setStatus $ "Empty file: " ++ path
-            else do
-              -- closeFile
-              if writable perm
-                then fileWrite .= True
-                else do
-                  fileWrite .= False
-              -- setStatus $ "No write permission: " ++ path
-              fileSize .= size
-              fileOffset .= 0
-              fileRow .= 0
-              hexOffset .= 0
-              mmapOffset .= -1
-              perfCount .= 0
-              enterOffset .= ""
-              ext <- lookupExtent Editor
-              case ext of
-                Nothing -> setStatus "internal error"
-                Just (Extent _ _ (_, h)) ->
-                  let h' = h - 1
-                   in do
-                        updateMmap h'
-                        mmapFile <- use file
-                        unless (isNothing mmapFile) $ do
-                          setStatus $
-                            "File opened: "
-                              ++ path
-                              ++ "; size: "
-                              ++ show size
-                              ++ "; mode: "
-                              ++ if writable perm
-                                then "ReadWrite"
-                                else "ReadOnly"
-                          mode .= Edit
+      rawPerm <- liftIO ((try $ getPermissions path) :: IO (Either IOError Permissions))
+      case rawPerm of
+        Left _ -> setStatus $ "Cannot check permission: " ++ path
+        Right perm ->
+          if readable perm
+            then do
+              rawSize <- liftIO ((try $ getFileSize path) :: IO (Either IOError Integer))
+              case rawSize of
+                Left _ -> setStatus $ "Cannot check size: " ++ path
+                Right size ->
+                  if size == 0
+                    then setStatus $ "Empty file: " ++ path
+                    else do
+                      -- closeFile
+                      if writable perm
+                        then fileWrite .= True
+                        else do
+                          fileWrite .= False
+                      -- setStatus $ "No write permission: " ++ path
+                      fileSize .= size
+                      fileOffset .= 0
+                      fileRow .= 0
+                      hexOffset .= 0
+                      mmapOffset .= -1
+                      perfCount .= 0
+                      enterOffset .= ""
+                      ext <- lookupExtent Editor
+                      case ext of
+                        Nothing -> setStatus "internal error"
+                        Just (Extent _ _ (_, h)) ->
+                          let h' = h - 1
+                          in do
+                                updateMmap h'
+                                mmapFile <- use file
+                                unless (isNothing mmapFile) $ do
+                                  setStatus $
+                                    "File opened: "
+                                      ++ path
+                                      ++ "; size: "
+                                      ++ show size
+                                      ++ "; mode: "
+                                      ++ if writable perm
+                                        then "ReadWrite"
+                                        else "ReadOnly"
+                                  mode .= Edit
         else setStatus $ "No read permission: " ++ path
     else setStatus $ "File not exist: " ++ path
   exitPrompt
@@ -243,7 +249,7 @@ updateMmap h = do
       oldBufferSize = case oldFile of
         Nothing -> (-1)
         Just (_, _, _, s) -> s
-   in unless (newOffset == oldOffset && bufferSize == oldBufferSize) $ do
+   in unless (newOffset == oldOffset && safeBufferSize == oldBufferSize) $ do
         closeMmap
         mmapFile <- liftIO ((try $ mmapFilePtr path perm rawOffset) :: IO (Either IOError (Ptr a, Int, Int, Int)))
         case mmapFile of
@@ -255,56 +261,73 @@ updateMmap h = do
             file .= Just f
             fillBuffer h
 
--- setStatus $ path ++ ", " ++ show rawOffset
-
 fillBuffer :: Int -> EventM AppName AppState ()
 fillBuffer h = do
   mmapFile <- use file
   pCnt <- use perfCount
   size <- use fileSize
   mmapOff <- use mmapOffset
-  modificationBuf <- use modificationBuffer
   let (ptr, _, o, _) = fromMaybe undefined mmapFile
       rawSize = 48 * (h - 1)
       defaultSize = 12 * 1024
       bufferSize = max defaultSize ((defaultSize - rawSize) `mod` defaultSize + rawSize)
       safeBufferSize = min bufferSize $ fromInteger $ size - mmapOff
    in do
-        buffer <- liftIO $ generateM safeBufferSize (peek . plusPtr (plusPtr ptr o))
-        let mapped = map (\(off, updated) -> (off - fromInteger mmapOff, updated)) (M.toList modificationBuf)
-            filtered = filter (\(off, _) -> 0 <= off && off < safeBufferSize) mapped
-        fileBuffer .= buffer // filtered
-        perfCount .= pCnt + 1
-
--- setStatus $ "loaded buffer " ++ show (pCnt + 1)
+        buffer <- liftIO ((try $ generateM safeBufferSize (peek . plusPtr (plusPtr ptr o))) :: IO (Either IOError (Vector Word8)))
+        case buffer of
+          Left _ -> do
+            f <- use enterFile
+            closeFile
+            mode .= Cmd
+            setStatus $ "Error reading buffer from file: " ++ f
+          Right b -> do
+            fileBuffer .= b
+            perfCount .= pCnt + 1
+            -- setStatus $ "loaded buffer " ++ show (pCnt + 1)
 
 saveFileAs :: EventM AppName AppState ()
 saveFileAs = do
   path <- use enterFile
   newPath <- use newFile
-  liftIO $ copyFile path newPath
-  enterFile .= newPath
+  res <- liftIO ((try $ copyFile path newPath) :: IO (Either IOError ()))
+  case res of
+    Left e -> setStatus $ "Cannot copy to new file: " ++ show e
+    Right _ -> do
+      enterFile .= newPath
+      saveFile
   newFile .= ""
-  saveFile
   exitPrompt
 
 saveFile :: EventM AppName AppState ()
 saveFile = do
   path <- use enterFile
   modificationBuf <- use modificationBuffer
-  handle <- liftIO $ IO.openFile path ReadWriteMode
-  mapM
-    ( \(off, updated) -> do
-        liftIO $ IO.hSeek handle IO.AbsoluteSeek (fromIntegral off)
-        liftIO $ IO.hPutChar handle (chr $ fromIntegral $ updated))
-    (M.toList modificationBuf)
-  liftIO $ IO.hClose handle
+  rawHandle <- liftIO ((try $ IO.openFile path ReadWriteMode) :: IO (Either IOError IO.Handle))
+  case rawHandle of
+    Left _ -> setStatus $ "File not saved: Cannot open file: " ++ path
+    Right handle -> do
+      res <- mapM
+        ( \(off, updated) ->
+            liftIO ((try $ IO.hSeek handle IO.AbsoluteSeek off >> IO.hPutChar handle (chr $ fromIntegral updated)) :: IO (Either IOError ())))
+        (M.toList modificationBuf)
+      case sequence res of
+        Left e -> setStatus $ "Save file error: " ++ show e
+        Right _ -> do
+          modificationBuffer .= M.empty
+          setStatus $ "File saved: " ++ path
+      _ <- liftIO ((try $ IO.hClose handle) :: IO (Either IOError ()))
+      ext <- lookupExtent Editor
+      case ext of
+        Nothing -> setStatus "internal error"
+        Just (Extent _ _ (_, h)) -> fillBuffer (h - 1)
 
 closeMmap :: EventM AppName AppState ()
 closeMmap = do
   mmapFile <- use file
   case mmapFile of
-    Just (ptr, rs, _, _) -> liftIO $ munmapFilePtr ptr rs
+    Just (ptr, rs, _, _) -> do
+      _ <- liftIO ((try $ munmapFilePtr ptr rs) :: IO (Either IOError ()))
+      return ()
     Nothing -> return ()
 
 clearBuffer :: EventM AppName AppState ()

--- a/src/UI.hs
+++ b/src/UI.hs
@@ -220,15 +220,20 @@ drawEditor state = translateBy (Location (0, 1)) $ withAttr editorBgAttr $ repor
                 end = min (state ^. fileSize - 1) $ begin + 15
                 g :: Integer -> Widget AppName
                 g off =
-                  let attr =
-                        if state ^. fileOffset == off
-                          then foldl1' (<+>) $ zipWith (curry fun) [0 ..] hexStr
+                  let focusAttr = if state ^. hexMode then editorFocusAttr else editorWeakFocusAttr
+                      focusModAttr = if state ^. hexMode then editorModWeakFocusAttr else editorModFocusAttr
+                      (attr, hexRaw) = case M.lookup off (state ^. modificationBuffer) of
+                        Just byte -> (if state ^. fileOffset == off
+                          then foldl1' (<+>) $ zipWith (curry $ fun (focusModAttr, editorModAttr)) [0 ..] hexStr
+                          else withAttr editorModAttr $ str hexStr
+                          , map toUpper $ showHex byte "")
+                        Nothing -> (if state ^. fileOffset == off
+                          then foldl1' (<+>) $ zipWith (curry $ fun (focusAttr, editorAttr)) [0 ..] hexStr
                           else withAttr editorAttr $ str hexStr
-                      focusAttr = if state ^. hexMode then editorFocusAttr else editorWeakFocusAttr
-                      hexRaw = map toUpper $ showHex ((state ^. fileBuffer) ! fromInteger (off - (state ^. mmapOffset))) ""
+                          , map toUpper $ showHex ((state ^. fileBuffer) ! fromInteger (off - (state ^. mmapOffset))) "")
                       hexStr = if length hexRaw == 1 then '0' : hexRaw else hexRaw
-                      fun (i, c) =
-                        (if i == state ^. hexOffset then withAttr focusAttr . visible else withAttr editorAttr) $
+                      fun (fAttr, nAttr) (i, c) =
+                        (if i == state ^. hexOffset then withAttr fAttr . visible else withAttr nAttr) $
                           str [c]
                    in attr
              in foldl1' (<+>) $ g begin : map (padLeft (Pad 1) . g) [begin + 1 .. end]
@@ -260,12 +265,17 @@ drawEditor state = translateBy (Location (0, 1)) $ withAttr editorBgAttr $ repor
                 end = min (state ^. fileSize - 1) $ begin + 15
                 g :: Integer -> Widget AppName
                 g off =
-                  let attr =
-                        if state ^. fileOffset == off
+                  let focusAttr = if state ^. hexMode then editorWeakFocusAttr else editorFocusAttr
+                      focusModAttr = if state ^. hexMode then editorModWeakFocusAttr else editorModFocusAttr
+                      (attr, asciiVal) = case M.lookup off (state ^. modificationBuffer) of
+                        Just byte -> (if state ^. fileOffset == off
+                          then withAttr focusModAttr . visible
+                          else withAttr editorModAttr
+                          , chr $ fromIntegral byte)
+                        Nothing -> (if state ^. fileOffset == off
                           then withAttr focusAttr . visible
                           else withAttr editorAttr
-                      focusAttr = if state ^. hexMode then editorWeakFocusAttr else editorFocusAttr
-                      asciiVal = chr $ fromIntegral $ (state ^. fileBuffer) ! fromInteger (off - (state ^. mmapOffset))
+                          , chr $ fromIntegral $ (state ^. fileBuffer) ! fromInteger (off - (state ^. mmapOffset)))
                       asciiStr = if asciiVal >= ' ' && asciiVal <= '~' then [asciiVal] else "."
                    in attr $ str asciiStr
              in foldl1' (<+>) $ map g [begin .. end]
@@ -548,21 +558,19 @@ editHandler event = case event of
       off <- use fileOffset
       hexOff <- use hexOffset
       mmapOff <- use mmapOffset
-      let current = fileBuf ! fromInteger (off - mmapOff)
+      let current = case M.lookup off modificationBuf of
+            Just byte -> byte
+            Nothing -> fileBuf ! fromInteger (off - mmapOff)
           updated =
             if hexOff == 1
               then current .&. 0xF0 .|. fromIntegral c
               else current .&. 0x0F .|. fromIntegral c `shiftL` 4
-      fileBuffer .= fileBuf // [(fromInteger (off - mmapOff), updated)]
-      modificationBuffer .= M.insert (fromInteger off) updated modificationBuf
+      modificationBuffer .= M.insert off updated modificationBuf
     alterAscii :: Char -> EventM AppName AppState ()
     alterAscii c = do
-      fileBuf <- use fileBuffer
       modificationBuf <- use modificationBuffer
       off <- use fileOffset
-      mmapOff <- use mmapOffset
-      fileBuffer .= fileBuf // [(fromInteger (off - mmapOff), (toEnum . fromEnum) c)]
-      modificationBuffer .= M.insert (fromInteger off) ((toEnum . fromEnum) c) modificationBuf
+      modificationBuffer .= M.insert off ((toEnum . fromEnum) c) modificationBuf
 
 start :: IO ()
 start = void $ defaultMain app initState

--- a/src/UI.hs
+++ b/src/UI.hs
@@ -565,11 +565,15 @@ editHandler event = case event of
             if hexOff == 1
               then current .&. 0xF0 .|. fromIntegral c
               else current .&. 0x0F .|. fromIntegral c `shiftL` 4
+      fileBuffer .= fileBuf // [(fromInteger (off - mmapOff), updated)]
       modificationBuffer .= M.insert off updated modificationBuf
     alterAscii :: Char -> EventM AppName AppState ()
     alterAscii c = do
+      fileBuf <- use fileBuffer
       modificationBuf <- use modificationBuffer
       off <- use fileOffset
+      mmapOff <- use mmapOffset
+      fileBuffer .= fileBuf // [(fromInteger (off - mmapOff), (toEnum . fromEnum) c)]
       modificationBuffer .= M.insert off ((toEnum . fromEnum) c) modificationBuf
 
 start :: IO ()


### PR DESCRIPTION
also:
handle IO errors;
change modification buffer key type from Int to Integer, to support large files modification;
prevent fillBuffer from being called unnecessarily in the range of last file buffer